### PR TITLE
Hide token from nginx access logs

### DIFF
--- a/example/nginx/default.conf
+++ b/example/nginx/default.conf
@@ -21,8 +21,8 @@ server {
     keepalive_timeout 0;
     
     set $sanitized_request $request;
-    if ( $sanitized_request ~ (\/bot\d+):[-\w]+\/(\S+) ) {
-        set $sanitized_request $1:<hidden-token>/$2;
+    if ( $sanitized_request ~ (\w+)\s(\/bot\d+):[-\w]+\/(\S+)\s(.*) ) {
+        set $sanitized_request "$1 $2:<hidden-token>/$3 $4";
     }
     access_log /var/log/nginx/access.log token_filter;
 

--- a/example/nginx/default.conf
+++ b/example/nginx/default.conf
@@ -1,3 +1,8 @@
+# use $sanitized_request instead of $request to hide Telegram token
+log_format token_filter '$remote_addr - $remote_user [$time_local] '
+                        '"$sanitized_request" $status $body_bytes_sent '
+                        '"$http_referer" "$http_user_agent"';
+
 upstream telegram-bot-api {
     server api:8081;
 }
@@ -14,6 +19,12 @@ server {
     client_max_body_size 2G;
     client_body_buffer_size 30M;
     keepalive_timeout 0;
+    
+    set $sanitized_request $request;
+    if ( $sanitized_request ~ (\/bot\d+):[-\w]+\/(\S+) ) {
+        set $sanitized_request $1:<hidden-token>/$2;
+    }
+    access_log /var/log/nginx/access.log token_filter;
 
     location ~* \/file\/bot\d+:(.*) {
         rewrite ^/file\/bot(.*) /$1 break;


### PR DESCRIPTION
## Before fix
```
172.23.0.4 - - [04/Apr/2022:20:56:55 +0000] "POST /bot1234567890:ABGFmfQrmd0lcXeGFS1nbfk5FOGVoNdr4zU/deleteWebhook HTTP/1.1" 200 68 "-" "Python/3.9 aiohttp/3.8.1"
172.23.0.4 - - [04/Apr/2022:20:56:55 +0000] "POST /bot1234567890:ABGFmfQrmd0lcXeGFS1nbfk5FOGVoNdr4zU/setWebhook HTTP/1.1" 200 57 "-" "Python/3.9 aiohttp/3.8.1"

```

## After fix
```
172.23.0.4 - - [04/Apr/2022:20:56:55 +0000] "POST /bot1234567890:<hidden-token>/deleteWebhook HTTP/1.1" 200 68 "-" "Python/3.9 aiohttp/3.8.1"
172.23.0.4 - - [04/Apr/2022:20:56:55 +0000] "POST /bot1234567890:<hidden-token>/setWebhook HTTP/1.1" 200 57 "-" "Python/3.9 aiohttp/3.8.1"
```