### PR TITLE
Add docker secrets support for TELEGRAM_API_ID and TELEGRAM_API_HASH

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,7 +22,7 @@ file_env() {
         file_content=$(cat "$file_path")
         export "$var_name=$file_content"
       else
-        echo "error: file '$file_path' does not exist"
+        echo "error: $var_name=$file_path: file '$file_path' does not exist"
         exit 1
       fi
     fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -43,6 +43,27 @@ fi
 
 COMMAND="telegram-bot-api ${DEFAULT_ARGS}${CUSTOM_ARGS}"
 
+file_env() {
+  local var_name="$1"
+  local file_var_name="$2"
+
+  eval file_path="\$${file_var_name}"
+  eval current_value="\$${var_name}"
+
+  if [ -n "$file_path" ]; then
+    if [ -n "$current_value" ]; then
+      echo "Error: both ${file_var_name} and ${var_name} env vars are set, expected only one of them"
+      exit 1
+    fi
+
+    file_content=$(< "$file_path")
+    export "$var_name=$file_content"
+  fi
+}
+
+file_env "TELEGRAM_API_ID" "TELEGRAM_API_ID_FILE"
+file_env "TELEGRAM_API_HASH" "TELEGRAM_API_HASH_FILE"
+
 echo "$COMMAND"
 # shellcheck disable=SC2086
 exec $COMMAND

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,7 +17,7 @@ file_env() {
     exit 1
 
   else
-    if [ -n $file_path ]; then
+    if [ -n "$file_path" ] && [ "$file_path" != "" ]; then
       if [ -f "$file_path" ]; then
         file_content=$(cat "$file_path")
         export "$var_name=$file_content"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,34 @@
 #!/bin/sh
 set -e
 
+file_env() {
+  local var_name="$1"
+  local file_var_name="$2"
+
+  var_value=$(printenv "$var_name") || var_value=""
+  file_path=$(printenv "$file_var_name") || file_path=""
+
+  if [ -z "$var_value" ] && [ -z "$file_path" ]; then
+    echo "error: expected $var_name or $file_var_name env vars to be set"
+    exit 1
+
+  elif [ -n "$var_value" ] && [ -n "$file_path" ]; then
+    echo "both and $var_name $file_var_name env vars are set, expected only one of them"
+    exit 1
+
+  else
+    if [ -n $file_path ]; then
+      if [ -f "$file_path" ]; then
+        file_content=$(cat "$file_path")
+        export "$var_name=$file_content"
+      else
+        echo "error: file '$file_path' does not exist"
+        exit 1
+      fi
+    fi
+  fi
+}
+
 USERNAME=telegram-bot-api
 GROUPNAME=telegram-bot-api
 
@@ -9,6 +37,9 @@ chown ${USERNAME}:${GROUPNAME} "${TELEGRAM_WORK_DIR}"
 if [ -n "${1}" ]; then
   exec "${*}"
 fi
+
+file_env "TELEGRAM_API_ID" "TELEGRAM_API_ID_FILE"
+file_env "TELEGRAM_API_HASH" "TELEGRAM_API_HASH_FILE"
 
 DEFAULT_ARGS="--http-port 8081 --dir=${TELEGRAM_WORK_DIR} --temp-dir=${TELEGRAM_TEMP_DIR} --username=${USERNAME} --groupname=${GROUPNAME}"
 CUSTOM_ARGS=""
@@ -43,37 +74,7 @@ fi
 
 COMMAND="telegram-bot-api ${DEFAULT_ARGS}${CUSTOM_ARGS}"
 
-file_env() {
-  local var_name="$1"
-  local file_var_name="$2"
-
-  var_value=$(printenv "$var_name") || var_value=""
-  file_path=$(printenv "$file_var_name") || file_path=""
-
-  if [ -z "$var_value" ] && [ -z "$file_path" ]; then
-    echo "error: expected $var_name or $file_var_name env vars to be set"
-    exit 1
-
-  elif [ -n "$var_value" ] && [ -n "$file_path" ]; then
-    echo "both and $var_name $file_var_name env vars are set, expected only one of them"
-    exit 1
-
-  else
-    if [ -n $file_path ]; then
-      if [ -f "$file_path" ]; then
-        file_content=$(cat "$file_path")
-        export "$var_name=$file_content"
-      else
-        echo "error: file '$file_path' does not exist"
-        exit 1
-      fi
-    fi
-  fi
-}
-
-file_env "TELEGRAM_API_ID" "TELEGRAM_API_ID_FILE"
-file_env "TELEGRAM_API_HASH" "TELEGRAM_API_HASH_FILE"
-
 echo "$COMMAND"
+
 # shellcheck disable=SC2086
 exec $COMMAND

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -47,17 +47,27 @@ file_env() {
   local var_name="$1"
   local file_var_name="$2"
 
-  eval file_path="\$${file_var_name}"
-  eval current_value="\$${var_name}"
+  var_value=$(printenv "$var_name") || var_value=""
+  file_path=$(printenv "$file_var_name") || file_path=""
 
-  if [ -n "$file_path" ]; then
-    if [ -n "$current_value" ]; then
-      echo "Error: both ${file_var_name} and ${var_name} env vars are set, expected only one of them"
-      exit 1
+  if [ -z "$var_value" ] && [ -z "$file_path" ]; then
+    echo "error: expected $var_name or $file_var_name env vars to be set"
+    exit 1
+
+  elif [ -n "$var_value" ] && [ -n "$file_path" ]; then
+    echo "both and $var_name $file_var_name env vars are set, expected only one of them"
+    exit 1
+
+  else
+    if [ -n $file_path ]; then
+      if [ -f "$file_path" ]; then
+        file_content=$(cat "$file_path")
+        export "$var_name=$file_content"
+      else
+        echo "error: file '$file_path' does not exist"
+        exit 1
+      fi
     fi
-
-    file_content=$(< "$file_path")
-    export "$var_name=$file_content"
   fi
 }
 


### PR DESCRIPTION
# Summary
Resolves #19 

After this update users will be able to provide Telegram API credentials via env vars containing paths to files containing the actual values.

## Example showcase:
1. Create `./secrets` dir and containing `telegram_api_hash` and `telegram_api_id` files:
```
 secrets
├──  telegram_api_hash
└──  telegram_api_id
``` 

2. Fill the files with the actual credentials:
```
$ echo "12345" > ./secrets/telegram_api_id
$ echo "ba78...165ad" > ./secrets/telegram_api_hash
```

3. Create `docker-compose.yml`, for example:
```yml
services:
  telegram-bot-api:
    build: .

    environment:
      # in this section we set paths to the mounted secrets: 
      TELEGRAM_API_ID_FILE: /run/secrets/telegram_api_id
      TELEGRAM_API_HASH_FILE: /run/secrets/telegram_api_hash
    
    secrets:
      # here we define list of secrets that will be used by the service
      - telegram_api_id
      - telegram_api_hash

secrets:
  # here we define the secrets and their location on the host machine:
  telegram_api_id:
    file: ./secrets/telegram_api_id
  telegram_api_hash:
    file: ./secrets/telegram_api_hash

```

# Notes
I've also included checks for env vars presense:
```
$ docker run telegram-bot-api:latest
error: expected TELEGRAM_API_ID or TELEGRAM_API_ID_FILE env vars to be set
```

I think this will slightly improve user experience and will not break anything, as environmental variables containing Telegram API credentials were essential to run the telegram-bot-api anyway.

Please share your thoughts and whether any changes needed. 
Then I will update the README file to reflect the usecase changes.