### PR TITLE
feat(nginx): support `local-mode` file paths

### DIFF
--- a/example/nginx/default.conf
+++ b/example/nginx/default.conf
@@ -19,13 +19,20 @@ server {
     client_max_body_size 2G;
     client_body_buffer_size 30M;
     keepalive_timeout 0;
-    
+
     set $sanitized_request $request;
     if ( $sanitized_request ~ (\w+)\s(\/bot\d+):[-\w]+\/(\S+)\s(.*) ) {
         set $sanitized_request "$1 $2:<hidden-token>/$3 $4";
     }
     access_log /var/log/nginx/access.log token_filter;
 
+    # Handle full paths (e.g., "/var/lib/telegram-bot-api/TOKEN/videos/file_0.mp4")
+    location ~* ^/file\/bot[^/]+\/var\/lib\/telegram-bot-api(.*) {
+        rewrite ^/file\/bot[^/]+\/var\/lib\/telegram-bot-api(.*) /$1 break;
+        try_files $uri @files;
+    }
+
+    # Handle partial paths (e.g., "videos/file_0.mp4")
     location ~* \/file\/bot\d+:(.*) {
         rewrite ^/file\/bot(.*) /$1 break;
         try_files $uri @files;


### PR DESCRIPTION
With current `nginx` config, only paths from non-local mode are supported.

## `GetFile` method:
With **default** server mode, we get partial paths in response to `getFile`:
```json
{
    "ok": true,
    "result": {
        "file_id": "BAACAgIAAcFkBAAICqmd6lFGp13E7At4S0a-uNjkmm7-GAAKaZgACida8SxuViZdHuCi2NgQ",
        "file_unique_id": "AgADmmYAAoqAwds",
        "file_size": 1827971,
        "file_path": "videos/file_1.mp4"
    }
}
```

When we have **local mode** enabled via:
```yaml
services:
  api:
    image: aiogram/telegram-bot-api:latest
    environment:
      TELEGRAM_API_ID: "XXX"
      TELEGRAM_API_HASH: "YYY"
      TELEGRAM_LOCAL: true
```

We get response in format:
```json
{
    "ok": true,
    "result": {
        "file_id": "BAACAgIAAxkBAAICTGd6qXpvBnhq3ItimgcnNZlQye7EAAKwYgACdps4S1x0i-09A9asdgQ",
        "file_unique_id": "AgADsGIAAnabasds",
        "file_size": 2409359,
        "file_path": "/var/lib/telegram-bot-api/39054833810:AAGHKkVGZfAQQQNxVEdagjHXKdXfF2-Dasdk/videos/file_0.mp4"
    }
}
```

And as specified in [here](https://core.telegram.org/bots/api#using-a-local-bot-api-server), it's **okay** and should work like this and bot API server must handle full paths.

## How are requests to download files sent:
URL format: `{{base_url}}/file/bot{{token}}/:file_path`

`file_path` partial: `videos/file_3.mp4` - currently handled ok

`file_path` full: `/var/lib/telegram-bot-api/7801471604:AAGHKkVGZfAQQQNxkvdag4fXKdXfF2-DDBk/videos/file_3.mp4` - 404 with current implementation

The current response for full path using `aiogram`:
```python
ClientResponseError(RequestInfo(url=URL('http://42.86.42.96/file/bot7801471604:AAGHKkVGZfAQQQNxkvdag4fXKdXfF2-DDBk//var/lib/telegram-bot-api/7801471604:AAGHKkVGZfAQQQNxkvdag4fXKdXfF2-DDBk/videos/file_3.mp4'), method='GET')>, status=404, message='Not Found', headers=<CIMultiDictProxy('Server': 'nginx/1.19.10', 'Date': 'Sun, 05 Jan 2025 17:38:47 GMT', 'Content-Type': 'text/html', 'Content-Length': '154', 'Connection': 'close')>)
```

## What this PR does:
Adds support for full-paths too.
Regex taken from [here](https://github.com/aiogram/telegram-bot-api/issues/10#issuecomment-1542743282)